### PR TITLE
Fix benchmark crate import errors

### DIFF
--- a/benches/troika_benchmark.rs
+++ b/benches/troika_benchmark.rs
@@ -4,8 +4,9 @@ extern crate rand;
 use rand::{thread_rng, Rng};
 
 use criterion::Criterion;
-use troika::Ftroika;
-use troika::Troika;
+use troika::ftroika::Ftroika;
+use troika::troika::Troika;
+use troika::Sponge;
 
 fn basic_troika() {
     let mut troika = Troika::default();


### PR DESCRIPTION
This fix enables benchmark, else the error messages are below:

```
   Compiling troika v0.1.2 (/home/jkrvivian/IOTA/troika)                                                   [7/1434]
error[E0432]: unresolved import `troika::Ftroika`
 --> benches/troika_benchmark.rs:7:5
  |
7 | use troika::Ftroika;
  |     ^^^^^^^^-------
  |     |       |
  |     |       help: a similar name exists in the module (notice the capitalization): `ftroika`
  |     no `Ftroika` in the root

error[E0599]: no method named `absorb` found for type `troika::ftroika::Ftroika` in the current scope
  --> benches/troika_benchmark.rs:20:12
   |
20 |     troika.absorb(&input);
   |            ^^^^^^ method not found in `troika::ftroika::Ftroika`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
4  | use sponge_preview::Sponge;
   |

error[E0599]: no method named `squeeze` found for type `troika::ftroika::Ftroika` in the current scope
  --> benches/troika_benchmark.rs:21:12
   |
21 |     troika.squeeze(&mut output);
   |            ^^^^^^^ method not found in `troika::ftroika::Ftroika`
   |
   = help: items from traits can only be used if the trait is in scope
help: the following trait is implemented but not in scope; perhaps add a `use` for it:
   |
4  | use sponge_preview::Sponge;
   |

error: aborting due to 3 previous errors

Some errors have detailed explanations: E0432, E0599.

For more information about an error, try `rustc --explain E0432`.
error: could not compile `troika`.

To learn more, run the command again with --verbose.
jkrvivian:troika $                                                                                       
                                                                                    

```